### PR TITLE
fix: inngest sleep duration to use calculated millisecond value where possible, sleep until specific date

### DIFF
--- a/app/api/subscriptions/route.ts
+++ b/app/api/subscriptions/route.ts
@@ -24,7 +24,8 @@ export async function POST(request: Request) {
     if (
       !isValidPositiveValue(parseInt(createSubscriptionRequest.amount)) ||
       !sleepDurationMs ||
-      sleepDurationMs < 60 * 60 * 1000 ||
+      (process.env.NEXT_PUBLIC_ALLOW_SHORT_TIMEFRAMES !== "true" &&
+        sleepDurationMs < 60 * 60 * 1000) ||
       !isValidNostrConnectUrl(createSubscriptionRequest.nostrWalletConnectUrl)
     ) {
       return new Response("One or more invalid subscription fields", {

--- a/app/subscriptions/[id]/page.tsx
+++ b/app/subscriptions/[id]/page.tsx
@@ -40,7 +40,7 @@ export default async function SubscriptionPage({
         }}
         subscriptionId={subscription.id}
         emailNotificationsSupported={areEmailNotificationsSupported(
-          subscription.sleepDuration,
+          Number(subscription.sleepDurationMs),
         )}
         beforeFormContent={
           <>

--- a/fly.toml
+++ b/fly.toml
@@ -41,3 +41,8 @@ processes = []
     interval = "15s"
     restart_limit = 0
     timeout = "2s"
+
+[[vm]]
+  cpu_kind = 'shared'
+  cpus = 1
+  memory = '1024mb'

--- a/lib/server/areEmailNotificationsSupported.ts
+++ b/lib/server/areEmailNotificationsSupported.ts
@@ -8,9 +8,9 @@ import ms from "ms";
  * @param sleepDuration timeframe between payments as a ms string
  * @returns true if sleepDuration is at least 1 hour
  */
-export function areEmailNotificationsSupported(sleepDuration: string) {
+export function areEmailNotificationsSupported(sleepDurationMs: number) {
   return (
-    millisecondsToHours(ms(sleepDuration)) >= 1 ||
+    millisecondsToHours(sleepDurationMs) >= 1 ||
     process.env.ALWAYS_ALLOW_NOTIFICATIONS === "true"
   );
 }


### PR DESCRIPTION
There seems to be some bug in inngest using `sleep()` and passing the `ms` library value, which sometimes triggers the event earlier than it should. Now a specific date is used.