### PR TITLE
feat: add endpoint to restart stuck subscriptions

### DIFF
--- a/types/RestartStuckSubscriptionsRequest.ts
+++ b/types/RestartStuckSubscriptionsRequest.ts
@@ -1,0 +1,3 @@
+export type RestartStuckSubscriptionsRequest = {
+  count: number;
+};

--- a/types/RestartStuckSubscriptionsResponse.ts
+++ b/types/RestartStuckSubscriptionsResponse.ts
@@ -1,0 +1,4 @@
+export type RestartStuckSubscriptionsResponse = {
+  processed: number;
+  total: number;
+};


### PR DESCRIPTION
There are **39** subscriptions that are stuck, **29** since the start of this year due to inngest issues or ZapPlanner step logic updates which made inngest discard the events.

I decided to discard subscriptions that had their last event older than the start of this year, as users might have considered them broken and I think it's a bad experience to be suddenly charged out of nowhere months later.

There is no auth on this endpoint, it simply re-triggers inngest events, which will be anyway discarded if the subscription is not ready to handle the event.

The endpoint has a `count` parameter required in the body, so that we can configure how many stuck subscriptions to restart in one go.