### PR TITLE
fix: create form lightning address validation

### DIFF
--- a/app/create/components/CreateSubscriptionForm.tsx
+++ b/app/create/components/CreateSubscriptionForm.tsx
@@ -187,14 +187,11 @@ export function CreateSubscriptionForm() {
             <input
               {...register("recipientLightningAddress", {
                 validate: async (address) => {
-                  if (!satoshiAmount) {
-                    // don't trigger when input field is empty (it's required and will have its own error message)
-                    return;
-                  }
                   setValidatingLightningAddress(true);
                   const { ln, errorMessage } = await validateLightningAddress(
                     address,
                     satoshiAmount || 0,
+                    !!satoshiAmount, // only validate amount if provided (there's a required attribute on the field too)
                   );
 
                   if (!errorMessage) {

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -7,6 +7,7 @@ export const isValidPositiveValue = (value: number) => {
 export const validateLightningAddress = async (
   address: string,
   amount: number,
+  validateAmount = true,
 ) => {
   let errorMessage: string | undefined = undefined;
   let ln: LightningAddress | undefined;
@@ -22,7 +23,7 @@ export const validateLightningAddress = async (
       await ln.fetch();
       if (ln.lnurlpData) {
         if (
-          amount * 1000 < ln.lnurlpData.min ||
+          (validateAmount && amount * 1000 < ln.lnurlpData.min) ||
           amount * 1000 > ln.lnurlpData.max
         ) {
           errorMessage = `This lightning address only accepts amounts between ${


### PR DESCRIPTION
Fixes https://github.com/getAlby/ZapPlanner/issues/81

There was a bug introduced when hiding the amount error message which stopped the LUD-18 fields showing.

Now we only validate the amount if it is provided, therefore there are no random error messages and the lightning address is still correctly validated.