### PR TITLE
fix: handles decimal points in fiat currency

### DIFF
--- a/app/confirm/components/SubscriptionSummary.tsx
+++ b/app/confirm/components/SubscriptionSummary.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { formatDistance, add, max } from "date-fns";
 import ms from "ms";
-import { MAX_RETRIES } from "lib/constants";
+import { MAX_RETRIES, SATS_CURRENCY } from "lib/constants";
 
 type SubscriptionSummaryProps = {
   values: {
@@ -36,7 +36,9 @@ export function SubscriptionSummary({
         right={
           <div>
             <span className="mono">
-              {parseInt(values.amount).toLocaleString()}
+              {values.currency === SATS_CURRENCY
+                ? parseInt(values.amount).toLocaleString()
+                : parseFloat(values.amount).toLocaleString()}
             </span>{" "}
             {values.currency}
           </div>
@@ -145,7 +147,10 @@ export function SubscriptionSummary({
         <SubscriptionSummaryItem
           left={`Total ${values.currency} sent`}
           right={`${
-            (values.numSuccessfulPayments || 0) * parseInt(values.amount)
+            (values.numSuccessfulPayments || 0) *
+            (values.currency === SATS_CURRENCY
+              ? parseInt(values.amount)
+              : parseFloat(values.amount))
           }`}
         />
       )}

--- a/app/create/components/CreateSubscriptionForm.tsx
+++ b/app/create/components/CreateSubscriptionForm.tsx
@@ -240,9 +240,25 @@ export function CreateSubscriptionForm() {
             <input
               {...register("amount", {
                 validate: (value) => {
-                  return !isValidPositiveValue(parseInt(value))
-                    ? "Please enter a positive value"
-                    : undefined;
+                  // Use parseInt for sats (no decimals), parseFloat for fiat currencies
+                  const numValue =
+                    watchedCurrency === SATS_CURRENCY
+                      ? parseInt(value)
+                      : parseFloat(value);
+
+                  if (!isValidPositiveValue(numValue)) {
+                    return "Please enter a positive value";
+                  }
+
+                  // Additional validation for sats to prevent decimals
+                  if (
+                    watchedCurrency === SATS_CURRENCY &&
+                    value.includes(".")
+                  ) {
+                    return "Millisatoshis (msat) are not supported. Please enter a whole number of sats.";
+                  }
+
+                  return undefined;
                 },
               })}
               className="zp-input flex-1"


### PR DESCRIPTION
fixes: #84

## **Database Schema Decision: Handling Fiat Currency Precision in ZapPlanner**

Hi,

I've been working on fixing decimal amount handling in ZapPlanner and discovered a critical architectural inconsistency if we handle the decimal places in fiat currecy just by parseFloat everywhere.

### **Current Problem:**
- Users enter fiat amounts like `$2.21 USD`
- Backend converts to satoshis: `$2.21 → 4235.67 sats`
- Database stores: `amount: 4236 (Int), currency: "USD"` ← **Inconsistent!**
- Payment logic treats stored amount as fiat, causing massive overcharging

### **Two Architectural Approaches:**

#### **Option A: Change Schema to Float**
```prisma
model Subscription {
  amount   Float  // Store 4235.67 (exact satoshis)
  currency String // Store "SATS" (always)
}
```

**Pros:** Preserves exact precision, no rounding errors
**Cons:** Float precision issues, performance impact, breaks Lightning/Bitcoin conventions (whole satoshis)

#### **Option B: Keep Int Schema + Enhanced Storage**
```prisma
model Subscription {
  sats_amount           Int     // 4236 (rounded satoshis)  
  originalAmount   String? // "2.21" (user input)
  originalCurrency String? // "USD" (user selection)
}
```

**Pros:** Follows Bitcoin standards, better performance, maintains payment precision
**Cons:** Additional fields, slight complexity


### **Current Implementation:**
I've temporarily fixed this bug by storing `currency: "SATS"` to prevent double-conversion, but this loses the original currency information.

**What's your recommendation on the long-term architecture?**
